### PR TITLE
R: nporadio1.nl, nporadio2.nl

### DIFF
--- a/EasyDutch/Hide_Specific.txt
+++ b/EasyDutch/Hide_Specific.txt
@@ -737,7 +737,6 @@ farm-date.com##.hide-for-small-only:has-text(Sponsors)
 slam.nl##.holder-ads
 basketbal.vlaanderen##.holder--divider-top
 oogtv.nl##.home-banner
-nporadio2.nl##.home-module--advertisement
 racingnews365.nl##.homepage-casino-wrapper
 jan-magazine.nl##.homepage-marquee
 sexylingerie-winkel.be##.homepage-seo-footer
@@ -1023,7 +1022,6 @@ schie.nu##[class^="my-"]:has(img[src*="/images/banner/"])
 appletips.nl##[class^="ph_block"]
 nedporno.com##[class^="r1ght-pl4yer"]:has([src*="ads"])
 visserijnieuws.nl##[class^="row advertentie-"]:not([class*="advertentie-1"])
-nporadio1.nl##[class^="sc-1o7zata"]:has-text(advert):has([id^="adid"]):has(script[src*="/adcdn."])
 pornolekker.nl##[class^="Scl"]:has([src^="//ads"])
 klimaatinfo.nl##[class^="space"]:has(.adsbygoogle)
 gaynews.nl##[class^="va"]:has([class*="banner"])
@@ -1203,7 +1201,6 @@ leerzaam.com##p:has(.adsbygoogle)
 creditexpo.nl##p:has(a[href]:has(img[src*="creditexpo.nl/wp-content/uploads/"][width="300"]))
 radio182.nl##section.elementor-element:has(h3:has-text(MOGELIJK GEMAAKT DOOR))
 iex.nl##section:has-text(advertentie)
-nporadio1.nl##section[class]:has-text(advert):has([id^="adid"]):has(script[src*="/adcdn."])
 oops.nl##table[cellspacing="30"]
 surfplaza.be##td.di1:has(img[src$="/yourad.gif"])
 marktplaats.nl,2dehands.be##ul.mp-Listings > li.mp-Listing:has(:scope > .mp-Listing-coverLink > .mp-Listing-group > .mp-Listing-group--price-date-feature > span.mp-Listing-priority > span:has-text(/^Topadvertentie$/))


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->
 > Note: Every header with an `*` is **required**. <br>
 > Not following this will result in invalid Pull Requests.
### Prerequisites *
<!-- Check the appropriate boxes before you submit your issue -->
- [x] This is a **Dutch** website / Het is een **Nederlandse** website
- [x] I performed a [cursory search of the issue tracker](https://github.com/EasyDutch-uBO/EasyDutch/issues) to avoid opening a duplicate issue / Geen **duplicaten**!!
- [x] Only ads or anti-adblock / Alleen advertenties of anti-adblock
- [x] Filters were [updated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#purge-all-caches) before reproducing an issue / Filterlijsten zijn [geüpdated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#update-now) voordat dit probleem werd gereproduceerd
- [x] I have updated my browser to the most recent version / Ik heb mijn browser geüpdated naar de meest recente verie
- [x] I tried to reproduce the issue when...
    - [ ] uBlock Origin with default lists / uBlock Origin met standaard filterlijsten
    - [ ] uBlock Origin is the only extension / uBlock Origin is de enige extensie

### URL(s) where the issue occurs *
- `nporadio1.nl`
- `nporadio2.nl`

### Describe the issue *
Removed two redundant filters because class selectors don't exist anymore on the websites:
- `nporadio2.nl##.home-module--advertisement`
- `nporadio1.nl##[class^="sc-1o7zata"]:has-text(advert):has([id^="adid"]):has(script[src*="/adcdn."])`

Removed one filter because it hides part of the legitimate content (see screenshot):
- `nporadio1.nl##section[class]:has-text(advert):has([id^="adid"]):has(script[src*="/adcdn."])`

### Screenshot(s)
<details>
  <summary> Screenshot(s) </summary>
  <img width="1216" alt="image" src="https://user-images.githubusercontent.com/734181/176416207-08a8b343-d20c-4e79-bfc1-9aec438bd303.png">
</details> 

### Configuration / Configuratie *
<!-- List all the changes you've made to uBO's default settings here, by copying the information given by uBO's Dashboard under `Support`, `Troubleshooting Information`. -->
<!-- Geef hier een lijst van alle wijzigingen die u heeft aangebracht in de standaardinstellingen van uBO, door de informatie te kopiëren die door uBO's Dashboard is gegeven onder `Ondersteuning`, `Probleemoplossingsinformatie`. -->
<details><summary>Troubleshooting Information / Probleemoplossingsinformatie</summary>
      
```yaml
<!-- [Put the copied text here, by replacing this line / Zet hier de gekopieerde tekst neer, door deze regel te overschrijven] -->
```
</details>

### Notes
The filter that hides the legitimate content on `nporadio1.nl` can be safely removed, because the script for the Ster advert is already actively blocked.

### Privacy *
By submitting this issue, you agree that this report does not contain private info, also not in the screenshots.
Dit issue bevat geen persoonlijke informatie, ook niet in de screenshots.
- [x] I agree to follow this condition / Ik ga akkoord met deze voorwaarde
