### PR TITLE
A: vandale.nl & vandale.be

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Fallback to project maintainer
 *	@Nomes77
+* @JohnyP36

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-# Fallback to project maintainer
-*	@Nomes77
+* @Nomes77
 * @JohnyP36

--- a/EasyDutch/Block_Resources.txt
+++ b/EasyDutch/Block_Resources.txt
@@ -4,6 +4,7 @@
 !
 ! 2023-10-23
 ||b-cdn.net/w_/*-banner-$image,domain=dtvnieuws.nl|omroephorstaandemaas.nl|omroepvenlo.nl|roulettefm.nl|rtvstichtsevecht.nl|wos.nl
+||ecdn.menselijklichaam.nl/banners/$images
 /production/uploads/partners/*$image,domain=dutchitchannel.nl
 ||nieuwrechts.nl/api/advertise-deliver/$xhr,1p
 ! 2023-10-16

--- a/EasyDutch/Block_Whitelist.txt
+++ b/EasyDutch/Block_Whitelist.txt
@@ -2,6 +2,8 @@
 ! Description: Whitelist for specific URLs on Dutch websites
 ! Last updated: %timestamp%
 !
+! 2023-10-23
+@@||vandale.*/*/images/*_300x250.$image,1p
 ! 2023-10-13
 @@||rambla.be/players/video-js/video-js-plugins/videojs.ads.min.js$script,1p
 ! 2023-08-01


### PR DESCRIPTION
Counter EasyList blocking 1p "ads"
 - https://www.vandale.nl/gratis-woordenboek/nederlands/betekenis/voorgaand
 - https://www.vandale.be/gratis-woordenboek/nederlands/betekenis/voorgaand

<!-- Replace the bracketed [...] placeholders with your own information. -->
 > Note: Every header with an `*` is **required**. <br>
 > Not following this will result in invalid Pull Requests.
### Prerequisites *
<!-- Check the appropriate boxes before you submit your issue -->
- [x] This is a **Dutch** website / Het is een **Nederlandse** website
- [x] I performed a [cursory search of the issue tracker](https://github.com/EasyDutch-uBO/EasyDutch/issues) to avoid opening a duplicate issue / Geen **duplicaten**!!
- [x] Only ads or anti-adblock / Alleen advertenties of anti-adblock
- [x] Filters were [updated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#purge-all-caches) before reproducing an issue / Filterlijsten zijn [geüpdated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#update-now) voordat dit probleem werd gereproduceerd
- [x] I have updated my browser to the most recent version / Ik heb mijn browser geüpdated naar de meest recente verie
- [x] I tried to reproduce the issue when...
    - [ ] uBlock Origin with default lists / uBlock Origin met standaard filterlijsten
    - [ ] uBlock Origin is the only extension / uBlock Origin is de enige extensie

### URL(s) where the issue occurs *
<!-- At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks (`) surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.
Geef de link van de website waar het probleem zich voordoet. -->
`vandale.nl` & `vandale.be`

### Describe the issue *
<!-- Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder. -->
<!-- Wees zo duidelijk mogelijk: niemand kan je gedachten lezen en niemand kijkt over je schouder mee. -->
EasyList blocks elements on VanDale that are not really ads

### Privacy *
By submitting this issue, you agree that this report does not contain private info, also not in the screenshots.
Dit issue bevat geen persoonlijke informatie, ook niet in de screenshots.
- [x] I agree to follow this condition / Ik ga akkoord met deze voorwaarde
