### PR TITLE
Ads on doorbraak.be

### DIFF
--- a/EasyDutch/Block_Resources.txt
+++ b/EasyDutch/Block_Resources.txt
@@ -3,6 +3,7 @@
 ! Last updated: %timestamp%
 !
 ! 2023-11-24
+||doorbraak.be/wp-json/api/*/ads$xhr
 ||grootnieuwsradio.nl/advertisements$xhr
 ||grootnieuwsradio.nl/cache/*/advertisements/$image
 ! 2023-11-21

--- a/EasyDutch/Hide_Specific.txt
+++ b/EasyDutch/Hide_Specific.txt
@@ -2,6 +2,8 @@
 ! Description: Filters for hiding elements on specific Dutch websites
 ! Last updated: %timestamp%
 !
+! 2023-11-24
+doorbraak.be##a[href^="https://vnz.be"]:upward(div)
 ! 2023-11-20
 nl.radio.net###headerTopBar ~ div:has(div#RAD_D_station_top)
 goudengids.be##.banner-boxes-holder
@@ -927,7 +929,6 @@ appletips.nl###singleab
 petitie24.nl###tekstpetitie > :has-text(advert)
 petitie24.nl###tekstpetitie > :has-text(advert) + div
 online-radio.nl###top_ad-360
-doorbraak.be###top-advertisement-area
 eredivisie.ws,f1-gp.nl,formule1.ws,formule1-race.nl,gaming-nieuws.nl,gazetvandaag.be,giganieuws.nl,grandprix.ws,hotstreams.nl,jupilerproleague.eu,krantvandaag.nl,nieuwsgigant.nl,recepten-vandaag.nl,voetbal-vandaag.nl###topbox
 starnieuws.com###topstory > div:has-text(Advertentie)
 hotradiohits.nl###tpl_banners


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->
 > Note: Every header with an `*` is **required**. <br>
 > Not following this will result in invalid Pull Requests.
### Prerequisites *
<!-- Check the appropriate boxes before you submit your issue -->
- [X] This is a **Dutch** website / Het is een **Nederlandse** website
- [X] I performed a [cursory search of the issue tracker](https://github.com/EasyDutch-uBO/EasyDutch/issues) to avoid opening a duplicate issue / Geen **duplicaten**!!
- [X] Only ads or anti-adblock / Alleen advertenties of anti-adblock
- [X] Filters were [updated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#purge-all-caches) before reproducing an issue / Filterlijsten zijn [geüpdated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#update-now) voordat dit probleem werd gereproduceerd
- [X] I have updated my browser to the most recent version / Ik heb mijn browser geüpdated naar de meest recente verie
- [X] I tried to reproduce the issue when...
    - [X] uBlock Origin with default lists / uBlock Origin met standaard filterlijsten
    - [X] uBlock Origin is the only extension / uBlock Origin is de enige extensie

### URL(s) where the issue occurs *
<!-- At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks (`) surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.
Geef de link van de website waar het probleem zich voordoet. -->
`https://doorbraak.be/`
`https://doorbraak.be/tscheldt-voelt-zich-uitgescholden`

### Describe the issue *
<!-- Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder. -->
<!-- Wees zo duidelijk mogelijk: niemand kan je gedachten lezen en niemand kijkt over je schouder mee. -->
Ad on right side of website

### Screenshot(s)
<!-- Screenshot(s) for difficult to describe visual issues are **mandatory**. Post links instead of **Inline Images** for Screenshots containing **Adult material**. -->
<!-- Is het **Volwassen materiaal** post dan linkjes in plaats van **Inline Images**. -->
<details><summary> Screenshot(s) </summary>

<!-- [Put here your screenshots / Zet hier uw screenshots neer] -->
</details> 

### Configuration / Configuratie *
<!-- List all the changes you've made to uBO's default settings here, by copying the information given by uBO's Dashboard under `Support`, `Troubleshooting Information`. -->
<!-- Geef hier een lijst van alle wijzigingen die u heeft aangebracht in de standaardinstellingen van uBO, door de informatie te kopiëren die door uBO's Dashboard is gegeven onder `Ondersteuning`, `Probleemoplossingsinformatie`. -->
<details><summary>Troubleshooting Information / Probleemoplossingsinformatie</summary>
      
```yaml
uBlock Origin: 1.53.0
Firefox: 119
filterset (summary):
 network: 88120
 cosmetic: 45571
 scriptlet: 19086
 html: 1107
listset (total-discarded, last-updated):
 removed:
  ublock-badware: null
  urlhaus-1: null
 default:
  user-filters: 674-0, never
  ublock-filters: 36586-131, 1h.39m
  ublock-privacy: 733-2, 1h.39m
  ublock-unbreak: 2197-1, 1h.39m
  ublock-quick-fixes: 213-2, 1h.39m
  easylist: 75665-579, 1h.39m
  easyprivacy: 32962-735, 1h.39m
  plowe-0: 3719-1, 1h.39m
  NLD-0: 2741-9, 1h.39m
filterset (user): [array of 529 redacted]
trustedset:
 added: [array of 9 redacted]
 removed:
  chrome-extension-scheme
  chrome-scheme
  edge-scheme
  moz-extension-scheme
  opera-scheme
  vivaldi-scheme
switchRuleset:
 added: [array of 1 redacted]
 removed:
  no-large-media: behind-the-scene false
hostRuleset:
 added: [array of 1343 redacted]
 removed:
  behind-the-scene * * noop
  behind-the-scene * image noop
  behind-the-scene * 3p noop
  behind-the-scene * inline-script noop
  behind-the-scene * 1p-script noop
  behind-the-scene * 3p-script noop
  behind-the-scene * 3p-frame noop
urlRuleset:
 added: [array of 14 redacted]
userSettings:
 advancedUserEnabled: true
 contextMenuEnabled: false
 prefetchingDisabled: false
hiddenSettings:
 autoCommentFilterTemplate: {{date}} {{url}}
 autoUpdateAssetFetchPeriod: 10
 autoUpdateDelayAfterLaunch: 60
 cacheStorageAPI: indexedDB
 filterAuthorMode: true
 popupFontSize: 12px
 trustedListPrefixes: user- ublock- NLD
 userResourcesLocation: [redacted]
supportStats:
 allReadyAfter: 1109 ms (selfie)
 maxAssetCacheWait: 157 ms
```
</details>

### Notes
<!-- Please investigate the issues you report -- this prevents burdening other volunteers. This is especially true for issues arising from settings which are very different from default ones. -->
<!-- [Write here the result of whatever investigation work you have done Schrijf hier het resultaat van het onderzoekswerk dat je hebt gedaan] -->

### Privacy *
By submitting this issue, you agree that this report does not contain private info, also not in the screenshots.
Dit issue bevat geen persoonlijke informatie, ook niet in de screenshots.
- [x] I agree to follow this condition / Ik ga akkoord met deze voorwaarde
