### PR TITLE
A: grandprixradio.nl

### DIFF
--- a/EasyDutch/Block_Resources.txt
+++ b/EasyDutch/Block_Resources.txt
@@ -3,6 +3,7 @@
 ! Last updated: %timestamp%
 !
 ! 2023-12-19
+||grandprixradio.nl/*/advertisements/
 ||knhs.nl/media/*/*-banner$image
 ||nieuwsgrazer.nl/images/ads/$domain=landbouwgrond.nu
 /wp-content/plugins/age-gate*$domain=nieuwslog.nl

--- a/EasyDutch/Hide_Specific.txt
+++ b/EasyDutch/Hide_Specific.txt
@@ -4,6 +4,7 @@
 !
 ! 2023-12-19
 112amersfoort.nl,112amsterdam.nl,112apeldoorn.nl,112arnhem.nl,112assen.nl,112barneveld.nl,112bunschoten.nl,112doetinchem.nl,112drenthe.nl,112ede.nl,112eindhoven.nl,112emmen.nl,112flevoland.nl,112harderwijk.nl,112hilversum.nl,112inbeeld.nl,112lelystad.nl,112meppel.nl,112nijkerk.nl,112overijssel.nl,112ridderkerk.nl,112rotterdam.nl,112scherpenzeel.nl,112schiedam.nl,112vallei.nl,112vechtdal.nl,112veenendaal.nl,112wageningen.nl,112zeewolde.nl,112zwolle.nl###bottom > h4:has-text(Ads)
+grandprixradio.nl##.advertisements
 hardware.info##.sidebar-item > a.sidebar-item__content:has-text(adv:)
 hardware.info##.category:has-text(Advert):upward(article.overview-item)
 janvissersweer.nl##img[width="300"][height="250"]:upward(aside.widget)


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->
 > Note: Every header with an `*` is **required**. <br>
 > Not following this will result in invalid Pull Requests.
### Prerequisites *
<!-- Check the appropriate boxes before you submit your issue -->
- [x] This is a **Dutch** website / Het is een **Nederlandse** website
- [x] I performed a [cursory search of the issue tracker](https://github.com/EasyDutch-uBO/EasyDutch/issues) to avoid opening a duplicate issue / Geen **duplicaten**!!
- [x] Only ads or anti-adblock / Alleen advertenties of anti-adblock
- [x] Filters were [updated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#purge-all-caches) before reproducing an issue / Filterlijsten zijn [geüpdated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#update-now) voordat dit probleem werd gereproduceerd
- [x] I have updated my browser to the most recent version / Ik heb mijn browser geüpdated naar de meest recente verie
- [ ] I tried to reproduce the issue when...
    - [ ] uBlock Origin with default lists / uBlock Origin met standaard filterlijsten
    - [ ] uBlock Origin is the only extension / uBlock Origin is de enige extensie

### URL(s) where the issue occurs *
<!-- At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks (`) surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.
Geef de link van de website waar het probleem zich voordoet. -->
https://grandprixradio.nl/

### Describe the issue *
<!-- Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder. -->
<!-- Wees zo duidelijk mogelijk: niemand kan je gedachten lezen en niemand kijkt over je schouder mee. -->
This rule blocks the age verification popup and thus ads

### Privacy *
By submitting this issue, you agree that this report does not contain private info, also not in the screenshots.
Dit issue bevat geen persoonlijke informatie, ook niet in de screenshots.
- [x] I agree to follow this condition / Ik ga akkoord met deze voorwaarde
