### PR TITLE
C: topgear.nl

### DIFF
--- a/EasyDutch/Hide_Specific.txt
+++ b/EasyDutch/Hide_Specific.txt
@@ -2,6 +2,8 @@
 ! Description: Filters for hiding elements on specific Dutch websites
 ! Last updated: %timestamp%
 !
+! 2024-01-04
+topgear.nl##div[id$="ad-wrap"]
 ! 2023-12-27
 !#if env_mobile
 mannenzaken.nl##.r89-mobile-rectangle-mid
@@ -275,7 +277,6 @@ techpulse.be##.wpb_wrapper > div[id^="techp"]:upward(.g-cols.wpb_row)
 techpulse.be##.wpb_wrapper:has( > div[class^="g"]):upward(section[class$="wpb_row height_small"]):not(:nth-of-type(1))
 telefoonboek.nl###tbresult-top
 telefoonboek.nl##[class^="detail-leaderbord"]:has(.adsbygoogle)
-topgear.nl##div:has( > div[style]:has-text(/advert/i):has(div[id]))
 touretappe.nl###right .desktopad[id*="TOURETAPPE_300"]:upward(1)
 trucks.nl##.highlighted-advertisers:upward(.row)
 tvgids24.nl###shortads


### PR DESCRIPTION
<!-- Replace the bracketed [...] placeholders with your own information. -->
 > Note: Every header with an `*` is **required**. <br>
 > Not following this will result in invalid Pull Requests.
### Prerequisites *
<!-- Check the appropriate boxes before you submit your issue -->
- [x] This is a **Dutch** website / Het is een **Nederlandse** website
- [x] I performed a [cursory search of the issue tracker](https://github.com/EasyDutch-uBO/EasyDutch/issues) to avoid opening a duplicate issue / Geen **duplicaten**!!
- [x] Only ads or anti-adblock / Alleen advertenties of anti-adblock
- [x] Filters were [updated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#purge-all-caches) before reproducing an issue / Filterlijsten zijn [geüpdated](https://github.com/gorhill/uBlock/wiki/Dashboard:-Filter-lists#update-now) voordat dit probleem werd gereproduceerd
- [x] I have updated my browser to the most recent version / Ik heb mijn browser geüpdated naar de meest recente verie
- [x] I tried to reproduce the issue when...
    - [ ] uBlock Origin with default lists / uBlock Origin met standaard filterlijsten
    - [ ] uBlock Origin is the only extension / uBlock Origin is de enige extensie

### URL(s) where the issue occurs *
<!-- At least one URL for a web page where the clearly described issue occurs is **mandatory**. The backticks (`) surrounding the URLs is important, it prevents the URL from being clickable. Warn with "NSFW" where applicable.
Geef de link van de website waar het probleem zich voordoet. -->
https://topgear.nl/formule-1/f1-auto-van-2026-kleiner-langzamer-en-een-nieuw-soort-drs/
### Describe the issue *
<!-- Be as clear as possible: nobody can read mind, and nobody is looking at your issue over your shoulder. -->
<!-- Wees zo duidelijk mogelijk: niemand kan je gedachten lezen en niemand kijkt over je schouder mee. -->
False positive: old rule whole article:

### Screenshot(s)
<!-- Screenshot(s) for difficult to describe visual issues are **mandatory**. Post links instead of **Inline Images** for Screenshots containing **Adult material**. -->
<!-- Is het **Volwassen materiaal** post dan linkjes in plaats van **Inline Images**. -->
<details><summary> Screenshot(s) </summary>

![afbeelding](https://github.com/EasyDutch-uBO/EasyDutch/assets/81161435/2dd9b4cf-330a-4a09-9cd0-5cc6ffa110da)
</details> 

### Privacy *
By submitting this issue, you agree that this report does not contain private info, also not in the screenshots.
Dit issue bevat geen persoonlijke informatie, ook niet in de screenshots.
- [x] I agree to follow this condition / Ik ga akkoord met deze voorwaarde
